### PR TITLE
Optionally end session when postInitScript exits

### DIFF
--- a/gnome/session.sh
+++ b/gnome/session.sh
@@ -81,6 +81,12 @@ xdg_find_needle() {
     return 1
 }
 
+kill_on_script_exit=
+if [ "$1" == "--kill-on-script-exit" ] ; then
+    kill_on_script_exit=true
+    shift
+fi
+
 # 'Xterm*vt100.pointerMode: 0' is to ensure that the pointer does not
 # disappear when a user types into the xterm.  In this situation, some
 # VNC clients experience a 'freeze' due to a bug with handling
@@ -154,7 +160,16 @@ if [ -f /etc/redhat-release ]; then
 fi
 
 if [ "$1" ]; then
-  gnome-terminal -- "$@" &
+  gnome-terminal --wait -- "$@" &
+  gnome_terminal_pid=$!
 fi
 
-gnome-session ${_GNOME_PARAMS}
+gnome-session ${_GNOME_PARAMS} &
+gnome_session_pid=$!
+
+if [ "$kill_on_script_exit" == true ] ; then
+    wait $gnome_terminal_pid
+    sleep 2
+else
+    wait $gnome_session_pid
+fi

--- a/kde/session.sh
+++ b/kde/session.sh
@@ -32,6 +32,12 @@
 echo 'XTerm*vt100.pointerMode: 0' | xrdb -merge
 vncconfig -nowin &
 
+kill_on_script_exit=
+if [ "$1" == "--kill-on-script-exit" ] ; then
+    kill_on_script_exit=true
+    shift
+fi
+
 if which startkde &>/dev/null; then
   startkde &
   kdepid=$!
@@ -77,7 +83,13 @@ if [ -f "${bg_image}" ]; then
 fi
 
 if [ "$1" ]; then
-  konsole -e "$@" &
+  konsole --nofork -e "$@" &
+  kde_terminal_pid=$!
 fi
 
-wait $kdepid
+if [ "$kill_on_script_exit" == true ] ; then
+    wait $kde_terminal_pid
+    sleep 2
+else
+    wait $kdepid
+fi

--- a/xfce/session.sh
+++ b/xfce/session.sh
@@ -81,6 +81,12 @@ xdg_find_needle() {
     return 1
 }
 
+kill_on_script_exit=
+if [ "$1" == "--kill-on-script-exit" ] ; then
+    kill_on_script_exit=true
+    shift
+fi
+
 # 'Xterm*vt100.pointerMode: 0' is to ensure that the pointer does not
 # disappear when a user types into the xterm.  In this situation, some
 # VNC clients experience a 'freeze' due to a bug with handling
@@ -118,6 +124,7 @@ install_geometry_script
 
 if [ "$1" ]; then
   xfce4-terminal --execute "$@" &
+  xfce4_terminal_pid=$!
 fi
 
 
@@ -136,4 +143,10 @@ if [ "$addr" ]; then
     echo "DBUS: $DBUS_SESSION_BUS_ADDRESS"
     xfconf-query -v -c xsettings -p /Xft/HintStyle -s hintnone
 fi
-wait $xfce4_session_pid
+
+if [ "$kill_on_script_exit" == true ] ; then
+    wait $xfce4_terminal_pid
+    sleep 2
+else
+    wait $xfce4_session_pid
+fi


### PR DESCRIPTION
The following types have been completed

* [X] Xfce
* [x] Gnome
* [x] kde

The following types already have this behaviour, though it is not
optional.

* terminal
* xterm

The following types do not support a `--script` option.

* chrome