### PR TITLE
Fix issue with xterm and terminal sessions

### DIFF
--- a/terminal/session.sh
+++ b/terminal/session.sh
@@ -84,6 +84,9 @@ options=(
     -xrm 'xterm*VT100.translations: #override Shift Ctrl <Key>V: insert-selection(PRIMARY)'
 )
 
+if [ "$1" == "--kill-on-script-exit" ] ; then
+    shift
+fi
 if [ -n "$1" ]; then
   xterm "${options[@]}" -e "$@"
 else

--- a/xterm/session.sh
+++ b/xterm/session.sh
@@ -40,6 +40,9 @@ static char root_weave_bits[] = {
 EOF
 )
 
+if [ "$1" == "--kill-on-script-exit" ] ; then
+    shift
+fi
 if [ -n "$1" ]; then
   xterm -e "$@"
 else


### PR DESCRIPTION
They were not handling the `--kill-on-script-exit` option correctly.

Previously they were passing that flag to the executed script potentially causing the script to complain about an unknown option.

Now they ignore the option entirely and exit when the script exits regardless.