### PR TITLE
Fix geometry script installation; annotate types with whether resizing is supported

### DIFF
--- a/chrome/metadata.yml
+++ b/chrome/metadata.yml
@@ -5,3 +5,4 @@
 :arch:
   - x86_64
 :scriptable: false
+:resizable: false

--- a/gnome/metadata.yml
+++ b/gnome/metadata.yml
@@ -4,3 +4,4 @@
 :url: https://www.gnome.org/
 :default: true
 :scriptable: true
+:resizable: true

--- a/gnome/session.sh
+++ b/gnome/session.sh
@@ -123,7 +123,7 @@ install_geometry_script() {
   local f destdir geom_sh
 
   f="flight-desktop_geometry.sh"
-  if ! geom_sh=$(xdg_data_search fight-desktop/bin/$f); then
+  if ! geom_sh=$(xdg_data_search flight/desktop/bin/$f); then
     destdir="$(xdg_data_home)/flight/desktop/bin"
     geom_sh="${destdir}/${f}"
     mkdir -p "${destdir}"

--- a/kde/metadata.yml
+++ b/kde/metadata.yml
@@ -3,3 +3,4 @@
   KDE Plasma Desktop (KDE 4). Plasma is KDE's desktop environment. Simple by default, powerful when needed.
 :url: https://kde.org/
 :scriptable: true
+:resizable: false

--- a/terminal/metadata.yml
+++ b/terminal/metadata.yml
@@ -2,3 +2,4 @@
 :summary: |
   Preconfigured terminal for Flight HPC environments.
 :scriptable: true
+:resizable: false

--- a/xfce/metadata.yml
+++ b/xfce/metadata.yml
@@ -3,3 +3,4 @@
   Xfce is a lightweight desktop environment for UNIX-like operating systems. It aims to be fast and low on system resources, while still being visually appealing and user friendly.
 :url: https://xfce.org/
 :scriptable: true
+:resizable: true

--- a/xfce/session.sh
+++ b/xfce/session.sh
@@ -104,21 +104,23 @@ install_geometry_script() {
 
   f="flight-desktop_geometry.sh"
   if ! geom_sh=$(xdg_data_search flight/desktop/bin/$f); then
-      destdir="$(xdg_data_home)/flight/desktop/bin"
-      geom_sh="${destdir}/${f}"
-      mkdir -p "${destdir}"
-      cp "${cw_ROOT}"/etc/sessions/xfce/${f} "${geom_sh}"
-      chmod 755 "${geom_sh}"
+    destdir="$(xdg_data_home)/flight/desktop/bin"
+    geom_sh="${destdir}/${f}"
+    mkdir -p "${destdir}"
+    cp "${flight_DESKTOP_type_root}"/${f} "${geom_sh}"
+    chmod 755 "${geom_sh}"
   fi
 
   f="flight-desktop_geometry.desktop"
   if ! xdg_config_search autostart/$f; then
-      destdir="$(xdg_config_home)/autostart"
-      mkdir -p "$destdir"
-      cp "${cw_ROOT}"/etc/sessions/xfce/${f}.tpl "${destdir}/${f}"
-      sed -i -e "s,_FLIGHT_DESKTOP_GEOMETRY_SH_,${geom_sh},g" "${destdir}/${f}"
+    destdir="$(xdg_config_home)/autostart"
+    mkdir -p "$destdir"
+    cp "${flight_DESKTOP_type_root}"/${f}.tpl "${destdir}/${f}"
+    sed -i -e "s,_FLIGHT_DESKTOP_GEOMETRY_SH_,${geom_sh},g" "${destdir}/${f}"
   fi
 }
+
+flight_DESKTOP_type_root="${flight_DESKTOP_type_root:-${flight_DESKTOP_root}/etc/types/xfce}"
 
 install_geometry_script
 

--- a/xterm/metadata.yml
+++ b/xterm/metadata.yml
@@ -3,3 +3,4 @@
   Minimal desktop environment with an xterm terminal window.
 :url: https://invisible-island.net/xterm/xterm.html
 :scriptable: true
+:resizable: false


### PR DESCRIPTION
* Fix detection of already installed of geometry script for gnome.
* Fix installation of geometry script for xfce.
* Add installation of geometry script for KDE.
* Add `resizable` metadata attribute indicating if a desktop type supports sensible resizing.