### PR TITLE
Hide chrome and terminal from output of desktop avail

### DIFF
--- a/chrome/metadata.yml
+++ b/chrome/metadata.yml
@@ -6,3 +6,5 @@
   - x86_64
 :scriptable: false
 :resizable: false
+:hidden: true
+

--- a/chrome/metadata.yml
+++ b/chrome/metadata.yml
@@ -6,5 +6,5 @@
   - x86_64
 :scriptable: false
 :resizable: false
-:hidden: true
+:disabled: true
 

--- a/kde/prepare.sh
+++ b/kde/prepare.sh
@@ -52,15 +52,15 @@ IFS=$'\n' groups=(
 )
 
 if [ "$distro" == "rhel8" ]; then
-  if ! yum --enablerepo=epel --disablerepo=epel-* repolist | grep -q '^*epel'; then
+  if ! yum --enablerepo=epel --disablerepo=epel-* repolist | grep -q '^epel'; then
     desktop_stage "Enabling repository: EPEL"
     yum -y install epel-release
     yum makecache
   fi
 
-  if ! yum repolist | grep -q '^PowerTools'; then
-    desktop_stage "Enabling repository: PowerTools"
-    yum config-manager --set-enabled PowerTools
+  if ! yum repolist | grep -q '^powertools'; then
+    desktop_stage "Enabling repository: powertools"
+    yum config-manager --set-enabled powertools
     yum makecache
   fi
 
@@ -82,11 +82,7 @@ fi
 
 if ! contains 'KDE' "${groups[@]}"; then
   desktop_stage "Installing package group: KDE"
-  if [ "$distro" == "rhel8" ]; then
-    yum --enablerepo=epel --disablerepo=epel-* -y groupinstall 'KDE'
-  else
-    yum -y groupinstall 'KDE'
-  fi
+  yum -y groupinstall 'KDE'
 fi
 
 if ! rpm -qa evince | grep -q evince; then

--- a/kde/verify.sh
+++ b/kde/verify.sh
@@ -53,13 +53,13 @@ IFS=$'\n' groups=(
 
 if [ "$distro" == "rhel8" ]; then
   desktop_stage "Repository: EPEL"
-  if ! yum --enablerepo=epel --disablerepo=epel-* repolist | grep -q '^*epel'; then
+  if ! yum --enablerepo=epel --disablerepo=epel-* repolist | grep -q '^epel'; then
     desktop_miss 'Repository: EPEL'
   fi
 
-  desktop_stage "Repository: PowerTools"
-  if ! yum repolist | grep -q '^PowerTools'; then
-    desktop_miss "Repository: PowerTools"
+  desktop_stage "Repository: powertools"
+  if ! yum repolist | grep -q '^powertools'; then
+    desktop_miss "Repository: powertools"
   fi
 
   desktop_stage "Package group: base-x"

--- a/terminal/metadata.yml
+++ b/terminal/metadata.yml
@@ -3,3 +3,5 @@
   Preconfigured terminal for Flight HPC environments.
 :scriptable: true
 :resizable: false
+:hidden: true
+

--- a/terminal/metadata.yml
+++ b/terminal/metadata.yml
@@ -3,5 +3,5 @@
   Preconfigured terminal for Flight HPC environments.
 :scriptable: true
 :resizable: false
-:hidden: true
+:disabled: true
 

--- a/xterm/metadata.yml
+++ b/xterm/metadata.yml
@@ -4,3 +4,5 @@
 :url: https://invisible-island.net/xterm/xterm.html
 :scriptable: true
 :resizable: false
+:disabled: true
+


### PR DESCRIPTION
Set `hidden` to true in metadata for `chrome` and `terminal` types.