### PR TITLE
Add conditionals for RHEL9

### DIFF
--- a/gnome/prepare.sh
+++ b/gnome/prepare.sh
@@ -85,6 +85,10 @@ if [ -f /etc/redhat-release ] && grep -q 'release 8' /etc/redhat-release; then
   distro=rhel8
 fi
 
+if [ -f /etc/redhat-release ] && grep -q 'release 9' /etc/redhat-release; then
+  distro=rhel9
+fi
+
 IFS=$'\n' groups=(
   $(
     yum grouplist hidden | \
@@ -93,7 +97,7 @@ IFS=$'\n' groups=(
   )
 )
 
-if [ "$distro" == "rhel8" ]; then
+if [ "$distro" == "rhel8" ] || [ "$distro" == "rhel9"]; then
   if ! contains 'base-x' "${groups[@]}"; then
     desktop_stage "Installing package group: base-x"
     yum -y groupinstall 'base-x'

--- a/gnome/prepare.sh
+++ b/gnome/prepare.sh
@@ -97,7 +97,7 @@ IFS=$'\n' groups=(
   )
 )
 
-if [ "$distro" == "rhel8" ] || [ "$distro" == "rhel9"]; then
+if [[ "$distro" == "rhel8" || "$distro" == "rhel9" ]]; then
   if ! contains 'base-x' "${groups[@]}"; then
     desktop_stage "Installing package group: base-x"
     yum -y groupinstall 'base-x'

--- a/gnome/verify.sh
+++ b/gnome/verify.sh
@@ -36,6 +36,10 @@ if [ -f /etc/redhat-release ] && grep -q 'release 8' /etc/redhat-release; then
   distro=rhel8
 fi
 
+if [ -f /etc/redhat-release ] && grep -q 'release 9' /etc/redhat-release; then
+  distro=rhel9
+fi
+
 desktop_stage "Flight Desktop prerequisites"
 if ! rpm -qa tigervnc-server-minimal | grep -q tigervnc-server-minimal; then
   desktop_miss 'Package: tigervnc-server-minimal'
@@ -62,7 +66,7 @@ if [ $UID == 0 ]; then
   fi
 fi
 
-if [ "$distro" == "rhel8" ]; then
+if [ "$distro" == "rhel8" ] || [ "$distro" == "rhel9"]; then
   desktop_stage "Package group: base-x"
   if ! contains 'base-x' "${groups[@]}"; then
     desktop_miss 'Package group: base-x'

--- a/kde/prepare.sh
+++ b/kde/prepare.sh
@@ -60,7 +60,7 @@ IFS=$'\n' groups=(
   )
 )
 
-if [ "$distro" == "rhel8" ] || [ "$distro" == "rhel9"]; then
+if [ "$distro" == "rhel8" ]; then
   if ! yum --enablerepo=epel --disablerepo=epel-* repolist | grep -q '^epel'; then
     desktop_stage "Enabling repository: EPEL"
     yum -y install epel-release
@@ -85,6 +85,31 @@ if [ "$distro" == "rhel8" ] || [ "$distro" == "rhel9"]; then
     desktop_stage "Installing package group: base-x"
     yum -y groupinstall 'base-x'
   fi
+elif [ "$distro" == "rhel9" ]; then
+  if [ "$stream" == "true" ]; then
+    if ! yum --disablerepo=epel* --enablerepo=epel-next repolist | grep -q '^epel-next'; then
+      desktop_stage "Enabling repository: EPEL Next"
+      yum -y install epel-release epel-next-release
+      yum makecache
+    fi
+  fi
+
+  if ! yum --enablerepo=epel --disablerepo=epel-* repolist | grep -q '^epel'; then
+    desktop_stage "Enabling repository: EPEL"
+    yum -y install epel-release
+    yum makecache
+  fi
+
+  if ! yum repolist | grep -q '^crb'; then
+    desktop_stage "Enabling repository: CRB"
+    yum config-manager --set-enabled crb
+    yum makecache
+  fi
+
+  if ! contains 'base-x' "${groups[@]}"; then
+    desktop_stage "Installing package group: base-x"
+    yum -y groupinstall 'base-x'
+  fi
 else
   if ! contains 'x window system' "${groups[@]}"; then
     desktop_stage "Installing package group: X Window System"
@@ -97,9 +122,16 @@ if ! contains 'fonts' "${groups[@]}"; then
   yum -y groupinstall 'Fonts'
 fi
 
-if ! contains 'kde' "${groups[@]}"; then
-  desktop_stage "Installing package group: KDE"
-  yum -y groupinstall 'KDE'
+if [ "$distro" == "rhel9" ]; then
+  if ! contains 'kde' "${groups[@]}"; then
+    desktop_stage "Installing package group: KDE Plasma Workspaces"
+    yum -y groupinstall 'KDE Plasma Workspaces'
+  fi
+else
+  if ! contains 'kde' "${groups[@]}"; then
+    desktop_stage "Installing package group: KDE"
+    yum -y groupinstall 'KDE'
+  fi
 fi
 
 if ! rpm -qa evince | grep -q evince; then

--- a/kde/prepare.sh
+++ b/kde/prepare.sh
@@ -38,6 +38,10 @@ if [ -f /etc/redhat-release ] && grep -q 'release 8' /etc/redhat-release; then
   distro=rhel8
 fi
 
+if [ -f /etc/redhat-release ] && grep -q 'release 9' /etc/redhat-release; then
+  distro=rhel9
+fi
+
 if [ -f /etc/redhat-release ] && grep -q 'Stream' /etc/redhat-release; then
   stream=true
 fi
@@ -56,7 +60,7 @@ IFS=$'\n' groups=(
   )
 )
 
-if [ "$distro" == "rhel8" ]; then
+if [ "$distro" == "rhel8" ] || [ "$distro" == "rhel9"]; then
   if ! yum --enablerepo=epel --disablerepo=epel-* repolist | grep -q '^epel'; then
     desktop_stage "Enabling repository: EPEL"
     yum -y install epel-release

--- a/kde/verify.sh
+++ b/kde/verify.sh
@@ -36,6 +36,10 @@ if [ -f /etc/redhat-release ] && grep -q 'release 8' /etc/redhat-release; then
   distro=rhel8
 fi
 
+if [ -f /etc/redhat-release ] && grep -q 'release 9' /etc/redhat-release; then
+  distro=rhel9
+fi
+
 if [ -f /etc/redhat-release ] && grep -q 'Stream' /etc/redhat-release; then
   stream=true
 fi
@@ -56,7 +60,7 @@ IFS=$'\n' groups=(
   )
 )
 
-if [ "$distro" == "rhel8" ]; then
+if [ "$distro" == "rhel8" ] || [ "$distro" == "rhel9" ]; then
   desktop_stage "Repository: EPEL"
   if ! yum --enablerepo=epel --disablerepo=epel-* repolist | grep -q '^epel'; then
     desktop_miss 'Repository: EPEL'

--- a/xfce/prepare.sh
+++ b/xfce/prepare.sh
@@ -38,6 +38,10 @@ if [ -f /etc/redhat-release ] && grep -q 'release 8' /etc/redhat-release; then
   distro=rhel8
 fi
 
+if [ -f /etc/redhat-release ] && grep -q 'release 9' /etc/redhat-release; then
+  distro=rhel9
+fi
+
 if ! rpm -qa tigervnc-server-minimal | grep -q tigervnc-server-minimal ||
    ! rpm -qa xorg-x11-xauth | grep -q xorg-x11-xauth; then
   desktop_stage "Installing Flight Desktop prerequisites"
@@ -52,7 +56,7 @@ IFS=$'\n' groups=(
   )
 )
 
-if [ "$distro" == "rhel8" ]; then
+if [ "$distro" == "rhel8" ] || [ "$distro" == "rhel9"] ; then
   if ! yum --enablerepo=epel --disablerepo=epel-* repolist | grep -q '^epel'; then
     desktop_stage "Enabling repository: EPEL"
     yum -y install epel-release

--- a/xfce/prepare.sh
+++ b/xfce/prepare.sh
@@ -56,7 +56,7 @@ IFS=$'\n' groups=(
   )
 )
 
-if [ "$distro" == "rhel8" ] || [ "$distro" == "rhel9"] ; then
+if [[ "$distro" == "rhel8" || "$distro" == "rhel9" ]] ; then
   if ! yum --enablerepo=epel --disablerepo=epel-* repolist | grep -q '^epel'; then
     desktop_stage "Enabling repository: EPEL"
     yum -y install epel-release

--- a/xfce/verify.sh
+++ b/xfce/verify.sh
@@ -36,6 +36,10 @@ if [ -f /etc/redhat-release ] && grep -q 'release 8' /etc/redhat-release; then
   distro=rhel8
 fi
 
+if [ -f /etc/redhat-release ] && grep -q 'release 9' /etc/redhat-release; then
+  distro=rhel9
+fi
+
 desktop_stage "Flight Desktop prerequisites"
 if ! rpm -qa tigervnc-server-minimal | grep -q tigervnc-server-minimal; then
   desktop_miss 'Package: tigervnc-server-minimal'
@@ -53,7 +57,7 @@ IFS=$'\n' groups=(
 )
 
 desktop_stage "Repository: EPEL"
-if [ "$distro" == "rhel8" ]; then
+if [ "$distro" == "rhel8" ] || [ "$distro" == "rhel9" ]; then
   if ! yum --enablerepo=epel --disablerepo=epel-* repolist | grep -q '^epel'; then
     desktop_miss 'Repository: EPEL'
   fi


### PR DESCRIPTION
This PR adds a few extra conditionals to the `prepare` and `verify` scripts to allow CentOS Stream 9 machines to use the `base-x` group the same way that CentOS 8 machines do.